### PR TITLE
chore(ci): take the release PR number from release-please's output

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -39,9 +39,22 @@ jobs:
       - name: Merge the release PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_PR: ${{ steps.release.outputs.pr }}
         run: |
-          PR=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --label 'autorelease: pending' \
-            --json number,author --jq '[.[] | select(.author.is_bot)] | .[0].number // empty')
+          # The action's own output is authoritative and immediate. Listing by
+          # label is not: the previous run created PR #61 at 00:14:03 and a
+          # label query 3 seconds later still returned nothing, so the release
+          # sat open.
+          PR=$(printf '%s' "$RELEASE_PR" | jq -r '.number // empty' 2>/dev/null || true)
+
+          if [ -z "$PR" ]; then
+            for _ in 1 2 3; do
+              PR=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --label 'autorelease: pending' \
+                --json number,author --jq '[.[] | select(.author.is_bot)] | .[0].number // empty')
+              [ -n "$PR" ] && break
+              sleep 5
+            done
+          fi
 
           if [ -z "$PR" ]; then
             echo "No pending release PR to merge."


### PR DESCRIPTION
Follow-up to #60, which moved the release-PR merge into the push-triggered job but still located the PR with `gh pr list --label 'autorelease: pending'`. That raced GitHub's indexing and lost: release-please created PR #61 at `00:14:03Z`, the merge step queried at `00:14:05.9Z`, and the step logged "No pending release PR to merge." The release then sat open, which is the exact stall #60 was meant to remove.

Now the PR number comes from `steps.release.outputs.pr`, which the action sets in the same job and which needs no indexing and no label. The label query survives as a retried fallback (3 attempts, 5s apart) for the case where the action updates an existing PR without re-emitting the output.

Note the commit prefix here is `chore(ci):` on purpose. #60 used `fix(ci):`, which release-please counted as a patch and turned into a pointless 3.1.1 release of a CI-only change. CI-only commits should use `chore` so they do not cut a release.

This one cannot be proven by reading, only by watching the next cycle: after this merges, the publish run should merge the open release PR by itself and 3.1.1 should land on PyPI with nobody clicking. I will confirm that it did.

https://claude.ai/code/session_01F1stiNzuNtJXoXtiW9ZCbs