### PR TITLE
chore(ci): run release-please and the release merge with the PAT

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,10 +23,13 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      # A push made with GITHUB_TOKEN does not start any workflow, so a release
+      # PR merged with it lands on main and then nothing publishes. Using the
+      # PAT keeps the chain alive and also lets CI run on the release PR.
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SDK_SYNC_PAT }}
           release-type: python
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
@@ -38,7 +41,7 @@ jobs:
       # would wait forever.
       - name: Merge the release PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SDK_SYNC_PAT }}
           RELEASE_PR: ${{ steps.release.outputs.pr }}
         run: |
           # The action's own output is authoritative and immediate. Listing by


### PR DESCRIPTION
Third and final link in the release chain, found the same way as the first two: by watching it fail.

#62 made the release PR merge itself, and it worked: run `00:18:40` logged "Merging release PR #61" and #61 is merged. But **3.1.1 never published**. PyPI is still on 3.1.0, there is no v3.1.1 tag, and no publish run exists after the merge.

The reason is a GitHub rule we have now hit in three different places: **a push made with `GITHUB_TOKEN` does not start any workflow**. Our own merge lands the release commit on main and then nothing reacts to it, so the run that would create the release and upload to PyPI never happens. 3.1.0 only published because a human (me) merged its release PR, which is a real user push.

Fix: run release-please and the merge step with `secrets.SDK_SYNC_PAT`, which already exists in this repo and is already what the api-sync workflow uses to open and auto-merge the sync PR. Two benefits: the merge push starts the publish run, and the release PR now gets CI (a `GITHUB_TOKEN`-opened PR never does).

The chain terminates: sync PR merged, publish runs, release-please opens the release PR, the merge step merges it, that push starts publish again, release-please creates the release, the publish job uploads to PyPI, and the merge step finds nothing pending and no-ops.

Merging this also unsticks 3.1.1, since the release commit is already on main and the next run will cut its release.

I will confirm on PyPI rather than assert it here. Every previous claim about this pipeline that I made from reading rather than watching turned out to be wrong.

https://claude.ai/code/session_01F1stiNzuNtJXoXtiW9ZCbs