### PR TITLE
feat(types): fix pagination cursor, billing fee, account type and wallet-create types

### DIFF
--- a/.api-sync/unmodeled.json
+++ b/.api-sync/unmodeled.json
@@ -233,13 +233,6 @@
   {
     "kind": "property",
     "schema": "CreatePayinOut",
-    "field": "billing_fee_amount",
-    "reason": "Not modeled on CreateEvmPayinResponse (Payin/GetPayinTrackResponse do model it).",
-    "owner": "eric@blindpay.com"
-  },
-  {
-    "kind": "property",
-    "schema": "CreatePayinOut",
     "field": "partner_fee",
     "reason": "Modeled instead as separate scalar fields (partner_fee_id, partner_fee_amount) rather than this nested object; same pattern as the pre-existing tracking_partner_fee divergence in allowlist.json.",
     "owner": "eric@blindpay.com"
@@ -277,20 +270,6 @@
     "schema": "CreatePayinQuoteOut",
     "field": "is_otc",
     "reason": "Not modeled on CreatePayinQuoteResponse.",
-    "owner": "eric@blindpay.com"
-  },
-  {
-    "kind": "property",
-    "schema": "CreateWalletIn",
-    "field": "external_id",
-    "reason": "Optional caller-supplied external reference; not modeled on CreateCustodialWalletInput.",
-    "owner": "eric@blindpay.com"
-  },
-  {
-    "kind": "property",
-    "schema": "CreateWalletIn",
-    "field": "name",
-    "reason": "REQUIRED by the API (CreateWalletIn.required includes name) but CreateCustodialWalletInput (customer_id, network only) never sends it -- likely a functional bug, not just a documentation gap; flagging for priority triage.",
     "owner": "eric@blindpay.com"
   },
   {
@@ -1015,15 +994,6 @@
     "schema": "WalletTokenOut",
     "field": "symbol",
     "reason": "Modeled under a different name: CustodialWalletBalanceToken uses `token` where the wire's WalletTokenOut object uses `symbol`.",
-    "owner": "eric@blindpay.com"
-  },
-  {
-    "kind": "enum",
-    "enum": "BankAccountType",
-    "missing_values": [
-      "saving"
-    ],
-    "reason": "Live defect, not just typing: the wire's real enum is [checking, saving] (singular); the SDK Literal is [checking, savings] (plural). Confirmed against packages/api-contract in blindpay-v2 and the API's own payout code, which branches on `account_type === 'saving'`. Do not auto-append \"saving\" as a 3rd member; this needs a coordinated rename PR (node and go already use the correct singular spelling).",
     "owner": "eric@blindpay.com"
   },
   {

--- a/src/blindpay/resources/custodial_wallets/custodial_wallets.py
+++ b/src/blindpay/resources/custodial_wallets/custodial_wallets.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 from ..._internal.api_client import InternalApiClient, InternalApiClientSync
 from ...types import BlindpayApiResponse, Network
@@ -30,6 +30,8 @@ class CustodialWalletBalance(TypedDict):
 class CreateCustodialWalletInput(TypedDict):
     customer_id: str
     network: Network
+    name: str
+    external_id: NotRequired[Optional[str]]
 
 
 CreateCustodialWalletResponse = CustodialWallet

--- a/src/blindpay/resources/payins/payins.py
+++ b/src/blindpay/resources/payins/payins.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, TypedDict
+from typing import List, NotRequired, Optional, TypedDict
 from urllib.parse import urlencode
 
 from ..._internal.api_client import InternalApiClient, InternalApiClientSync
@@ -92,7 +92,7 @@ class Payin(TypedDict):
     network: Network
     blindpay_bank_details: BankDetails
     is_otc: Optional[bool]
-    billing_fee_amount: Optional[str]
+    billing_fee_amount: Optional[float]
     pse_document_type: Optional[str]
     pse_full_name: Optional[str]
     pse_payment_link: Optional[str]
@@ -170,6 +170,7 @@ class GetPayinTrackResponse(TypedDict):
     network: Network
     blindpay_bank_details: BankDetails
     partner_fee_id: Optional[str]
+    billing_fee_amount: NotRequired[Optional[float]]
 
 
 class ExportPayinsInput(TypedDict):
@@ -194,6 +195,7 @@ class CreateEvmPayinResponse(TypedDict):
     blindpay_bank_details: BankDetails
     customer_id: str
     receiver_amount: float
+    billing_fee_amount: NotRequired[Optional[float]]
 
 
 class PayinsResource:

--- a/src/blindpay/types.py
+++ b/src/blindpay/types.py
@@ -1,4 +1,4 @@
-from typing import Generic, Literal, TypeVar, Union
+from typing import Generic, Literal, Optional, TypeVar, Union
 
 from typing_extensions import TypedDict
 
@@ -45,7 +45,7 @@ TransactionDocumentType = Literal[
     "invoice", "purchase_order", "delivery_slip", "contract", "customs_declaration", "bill_of_lading", "others"
 ]
 
-BankAccountType = Literal["checking", "savings"]
+BankAccountType = Literal["checking", "saving"]
 
 Currency = Literal["USDC", "USDT", "USDB", "BRL", "USD", "MXN", "COP", "ARS"]
 
@@ -334,8 +334,8 @@ class PaginationParams(TypedDict, total=False):
 
 class PaginationMetadata(TypedDict):
     has_more: bool
-    next_page: int
-    prev_page: int
+    next_page: Optional[str]
+    prev_page: Optional[str]
 
 
 class TrackingTransaction(TypedDict):

--- a/tests/resources/test_custodial_wallets.py
+++ b/tests/resources/test_custodial_wallets.py
@@ -28,6 +28,7 @@ class TestCustodialWallets:
                 {
                     "customer_id": "re_000000000000",
                     "network": "solana",
+                    "name": "My Solana Wallet",
                 }
             )
 
@@ -36,10 +37,44 @@ class TestCustodialWallets:
             assert response["data"]["id"] == "cw_000000000000"
             assert response["data"]["network"] == "solana"
             assert response["data"]["address"] == "So1ana1234567890"
+            # `name` is required on the wire (CreateWalletIn.required includes it);
+            # the create() body must actually carry it, not just the type.
             mock_request.assert_called_once_with(
                 "POST",
                 "/instances/in_000000000000/customers/re_000000000000/wallets",
-                {"network": "solana"},
+                {"network": "solana", "name": "My Solana Wallet"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_custodial_wallet_with_external_id(self):
+        """external_id is optional on the wire; proves it flows through when
+        supplied and that name alone (without external_id) still type-checks."""
+        mocked_wallet = {
+            "id": "cw_000000000000",
+            "customer_id": "re_000000000000",
+            "instance_id": "in_000000000000",
+            "network": "solana",
+            "address": "So1ana1234567890",
+            "created_at": "2025-01-01T00:00:00Z",
+        }
+
+        with patch.object(self.blindpay._api, "_request") as mock_request:
+            mock_request.return_value = {"data": mocked_wallet, "error": None}
+
+            response = await self.blindpay.wallets.custodial.create(
+                {
+                    "customer_id": "re_000000000000",
+                    "network": "solana",
+                    "name": "My Solana Wallet",
+                    "external_id": "your-database-id",
+                }
+            )
+
+            assert response["error"] is None
+            mock_request.assert_called_once_with(
+                "POST",
+                "/instances/in_000000000000/customers/re_000000000000/wallets",
+                {"network": "solana", "name": "My Solana Wallet", "external_id": "your-database-id"},
             )
 
     @pytest.mark.asyncio
@@ -162,6 +197,7 @@ class TestCustodialWalletsSync:
                 {
                     "customer_id": "re_000000000000",
                     "network": "solana",
+                    "name": "My Solana Wallet",
                 }
             )
 
@@ -171,7 +207,36 @@ class TestCustodialWalletsSync:
             mock_request.assert_called_once_with(
                 "POST",
                 "/instances/in_000000000000/customers/re_000000000000/wallets",
-                {"network": "solana"},
+                {"network": "solana", "name": "My Solana Wallet"},
+            )
+
+    def test_create_custodial_wallet_with_external_id(self):
+        mocked_wallet = {
+            "id": "cw_000000000000",
+            "customer_id": "re_000000000000",
+            "instance_id": "in_000000000000",
+            "network": "solana",
+            "address": "So1ana1234567890",
+            "created_at": "2025-01-01T00:00:00Z",
+        }
+
+        with patch.object(self.blindpay._api, "_request") as mock_request:
+            mock_request.return_value = {"data": mocked_wallet, "error": None}
+
+            response = self.blindpay.wallets.custodial.create(
+                {
+                    "customer_id": "re_000000000000",
+                    "network": "solana",
+                    "name": "My Solana Wallet",
+                    "external_id": "your-database-id",
+                }
+            )
+
+            assert response["error"] is None
+            mock_request.assert_called_once_with(
+                "POST",
+                "/instances/in_000000000000/customers/re_000000000000/wallets",
+                {"network": "solana", "name": "My Solana Wallet", "external_id": "your-database-id"},
             )
 
     def test_list_custodial_wallets(self):

--- a/tests/resources/test_payins.py
+++ b/tests/resources/test_payins.py
@@ -104,8 +104,8 @@ class TestPayins:
             ],
             "pagination": {
                 "has_more": True,
-                "next_page": 3,
-                "prev_page": 1,
+                "next_page": "pi_123",
+                "prev_page": "pi_123",
             },
         }
 
@@ -501,8 +501,8 @@ class TestPayinsSync:
             ],
             "pagination": {
                 "has_more": True,
-                "next_page": 3,
-                "prev_page": 1,
+                "next_page": "pi_123",
+                "prev_page": "pi_123",
             },
         }
 

--- a/tests/resources/test_payouts.py
+++ b/tests/resources/test_payouts.py
@@ -109,8 +109,8 @@ class TestPayouts:
             ],
             "pagination": {
                 "has_more": True,
-                "next_page": 3,
-                "prev_page": 1,
+                "next_page": "pi_123",
+                "prev_page": "pi_123",
             },
         }
 
@@ -694,8 +694,8 @@ class TestPayoutsSync:
             ],
             "pagination": {
                 "has_more": True,
-                "next_page": 3,
-                "prev_page": 1,
+                "next_page": "pi_123",
+                "prev_page": "pi_123",
             },
         }
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,256 @@
+"""Type-surface regression tests: each of these constructs an explicitly
+TypedDict-annotated literal, so pyright/mypy (both run over tests/) enforce
+the shape at the assignment itself -- not just at runtime equality. This is
+the proof that matters for a type-only fix: a wrong type here fails the type
+checker, not just a test assertion.
+"""
+
+from blindpay.resources.custodial_wallets.custodial_wallets import CreateCustodialWalletInput
+from blindpay.resources.payins.payins import BankDetails, CreateEvmPayinResponse, GetPayinTrackResponse, Payin
+from blindpay.types import BankAccountType, PaginationMetadata
+
+_BANK_DETAILS: BankDetails = {
+    "routing_number": "0",
+    "account_number": "0",
+    "account_type": "checking",
+    "swift_bic_code": "0",
+    "ach": {"routing_number": "0", "account_number": "0"},
+    "wire": {"routing_number": "0", "account_number": "0"},
+    "rtp": {"routing_number": "0", "account_number": "0"},
+    "beneficiary": {"name": "0", "address_line_1": "0", "address_line_2": None},
+    "receiving_bank": {"name": "0", "address_line_1": "0", "address_line_2": None},
+}
+
+
+class TestPaginationMetadataAcceptsStringCursors:
+    def test_string_next_page_and_prev_page(self):
+        meta: PaginationMetadata = {
+            "has_more": True,
+            "next_page": "pi_123",
+            "prev_page": "pi_123",
+        }
+        assert meta["next_page"] == "pi_123"
+        assert meta["prev_page"] == "pi_123"
+
+    def test_next_page_and_prev_page_are_nullable(self):
+        meta: PaginationMetadata = {
+            "has_more": False,
+            "next_page": None,
+            "prev_page": None,
+        }
+        assert meta["next_page"] is None
+        assert meta["prev_page"] is None
+
+
+class TestBillingFeeAmountIsNumeric:
+    def test_payin_accepts_a_float(self):
+        payin: Payin = {
+            "customer_id": "cus_000000000000",
+            "id": "pi_000000000000",
+            "pix_code": None,
+            "memo_code": None,
+            "clabe": None,
+            "status": "completed",
+            "manual_execution_status": None,
+            "payin_quote_id": "pq_000000000000",
+            "instance_id": "in_000000000000",
+            "tracking_transaction": None,
+            "tracking_payment": None,
+            "tracking_complete": None,
+            "tracking_partner_fee": None,
+            "created_at": "2025-01-01T00:00:00Z",
+            "updated_at": "2025-01-01T00:00:00Z",
+            "image_url": None,
+            "first_name": None,
+            "last_name": None,
+            "legal_name": None,
+            "type": "ach",
+            "payment_method": "ach",
+            "sender_amount": 1000,
+            "receiver_amount": 1000,
+            "token": "USDC",
+            "partner_fee_amount": 0,
+            "total_fee_amount": 0,
+            "commercial_quotation": 1,
+            "blindpay_quotation": 1,
+            "currency": "USD",
+            "billing_fee": 0,
+            "name": "John Doe",
+            "address": "0x0",
+            "network": "base",
+            "blindpay_bank_details": _BANK_DETAILS,
+            "is_otc": None,
+            "billing_fee_amount": 50.0,
+            "pse_document_type": None,
+            "pse_full_name": None,
+            "pse_payment_link": None,
+            "pse_tax_id": None,
+            "partner_fee_id": None,
+        }
+        assert payin["billing_fee_amount"] == 50.0
+
+    def test_get_payin_track_response_billing_fee_amount_omitted_type_checks(self):
+        # NotRequired: omitting the key entirely must still type-check.
+        without: GetPayinTrackResponse = {
+            "customer_id": "cus_000000000000",
+            "id": "pi_000000000000",
+            "pix_code": "0",
+            "memo_code": "0",
+            "clabe": "0",
+            "status": "completed",
+            "manual_execution_status": None,
+            "payin_quote_id": "pq_000000000000",
+            "instance_id": "in_000000000000",
+            "tracking_transaction": {
+                "step": "completed",
+                "status": "completed",
+                "transaction_hash": "0",
+                "completed_at": "0",
+            },
+            "tracking_payment": {
+                "step": "completed",
+                "provider_name": "0",
+                "provider_transaction_id": "0",
+                "provider_status": "0",
+                "estimated_time_of_arrival": "0",
+                "completed_at": "0",
+            },
+            "tracking_complete": {
+                "step": "completed",
+                "status": "completed",
+                "transaction_hash": "0",
+                "completed_at": "0",
+            },
+            "tracking_partner_fee": {"step": "completed", "transaction_hash": "0", "completed_at": "0"},
+            "created_at": "2025-01-01T00:00:00Z",
+            "updated_at": "2025-01-01T00:00:00Z",
+            "image_url": "0",
+            "first_name": "0",
+            "last_name": "0",
+            "legal_name": "0",
+            "type": "ach",
+            "payment_method": "ach",
+            "sender_amount": 1000,
+            "receiver_amount": 1000,
+            "token": "USDC",
+            "partner_fee_amount": 0,
+            "total_fee_amount": 0,
+            "commercial_quotation": 1,
+            "blindpay_quotation": 1,
+            "currency": "USD",
+            "billing_fee": 0,
+            "name": "John Doe",
+            "address": "0x0",
+            "network": "base",
+            "blindpay_bank_details": _BANK_DETAILS,
+            "partner_fee_id": None,
+        }
+        assert without.get("billing_fee_amount") is None
+
+    def test_get_payin_track_response_billing_fee_amount_is_numeric_when_present(self):
+        with_it: GetPayinTrackResponse = {
+            "customer_id": "cus_000000000000",
+            "id": "pi_000000000000",
+            "pix_code": "0",
+            "memo_code": "0",
+            "clabe": "0",
+            "status": "completed",
+            "manual_execution_status": None,
+            "payin_quote_id": "pq_000000000000",
+            "instance_id": "in_000000000000",
+            "tracking_transaction": {
+                "step": "completed",
+                "status": "completed",
+                "transaction_hash": "0",
+                "completed_at": "0",
+            },
+            "tracking_payment": {
+                "step": "completed",
+                "provider_name": "0",
+                "provider_transaction_id": "0",
+                "provider_status": "0",
+                "estimated_time_of_arrival": "0",
+                "completed_at": "0",
+            },
+            "tracking_complete": {
+                "step": "completed",
+                "status": "completed",
+                "transaction_hash": "0",
+                "completed_at": "0",
+            },
+            "tracking_partner_fee": {"step": "completed", "transaction_hash": "0", "completed_at": "0"},
+            "created_at": "2025-01-01T00:00:00Z",
+            "updated_at": "2025-01-01T00:00:00Z",
+            "image_url": "0",
+            "first_name": "0",
+            "last_name": "0",
+            "legal_name": "0",
+            "type": "ach",
+            "payment_method": "ach",
+            "sender_amount": 1000,
+            "receiver_amount": 1000,
+            "token": "USDC",
+            "partner_fee_amount": 0,
+            "total_fee_amount": 0,
+            "commercial_quotation": 1,
+            "blindpay_quotation": 1,
+            "currency": "USD",
+            "billing_fee": 0,
+            "name": "John Doe",
+            "address": "0x0",
+            "network": "base",
+            "blindpay_bank_details": _BANK_DETAILS,
+            "partner_fee_id": None,
+            "billing_fee_amount": 50.0,
+        }
+        assert with_it.get("billing_fee_amount") == 50.0
+
+    def test_create_evm_payin_response_billing_fee_amount_is_optional_and_numeric(self):
+        resp: CreateEvmPayinResponse = {
+            "id": "pi_000000000000",
+            "status": "completed",
+            "pix_code": None,
+            "memo_code": None,
+            "clabe": None,
+            "tracking_complete": None,
+            "tracking_payment": None,
+            "tracking_transaction": None,
+            "tracking_partner_fee": None,
+            "blindpay_bank_details": _BANK_DETAILS,
+            "customer_id": "cus_000000000000",
+            "receiver_amount": 1000,
+            "billing_fee_amount": 50.0,
+        }
+        assert resp.get("billing_fee_amount") == 50.0
+
+
+class TestBankAccountTypeUsesSingularSaving:
+    def test_saving_is_a_valid_value(self):
+        value: BankAccountType = "saving"
+        assert value == "saving"
+
+
+class TestCreateCustodialWalletInputRequiresName:
+    def test_name_is_required_and_sent(self):
+        data: CreateCustodialWalletInput = {
+            "customer_id": "cus_000000000000",
+            "network": "base",
+            "name": "My Wallet",
+        }
+        assert data["name"] == "My Wallet"
+
+    def test_external_id_is_optional(self):
+        data: CreateCustodialWalletInput = {
+            "customer_id": "cus_000000000000",
+            "network": "base",
+            "name": "My Wallet",
+        }
+        assert "external_id" not in data
+
+        with_external_id: CreateCustodialWalletInput = {
+            "customer_id": "cus_000000000000",
+            "network": "base",
+            "name": "My Wallet",
+            "external_id": "your-database-id",
+        }
+        assert with_external_id.get("external_id") == "your-database-id"

--- a/uv.lock
+++ b/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "blindpay"
-version = "3.0.0"
+version = "3.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Fixes four type-surface defects surfaced by `.api-sync/sync.py --audit-types` (added in #58) and a follow-up manual review. **These are type-surface changes for existing consumers, not new API surface** -- in every case the wire contract already behaved this way; the SDK's declared type was simply wrong, and this PR makes the type match the (unchanged) reality. Anyone relying on the old, incorrect type is the one currently at risk (a `str`-typed field that was always secretly a number, an `int`-typed field that was always secretly a nullable id string, an enum value the API has never accepted), not the other way around.

## The four fixes, quoting the contract for each

### 1. `PaginationMetadata.next_page` / `.prev_page`: `int` -> `Optional[str]`

Contract (`packages/api-contract/src/generic.schema.ts`): `next_page: z.string().nullish()`, example `"pi_123"`. It's a pagination cursor id, not a page number. This is the same defect that makes the go/php/swift SDKs throw at runtime on any paginated list call; TypedDicts aren't runtime-enforced, so python silently accepted whatever the wire sent -- the declared type was just misleading every typed consumer (autocomplete, mypy/pyright checks on their own code) into treating it as an integer.

### 2. `Payin.billing_fee_amount`: `Optional[str]` -> `Optional[float]`

Spec: `{"type": ["number", "null"], "description": "Billing fee in cents...", "example": 50}`. Every other monetary `_amount`/`_fee` field in this SDK is `float` -- including `Payout.billing_fee_amount`, already correct. `Payin.billing_fee_amount` was the one outlier.

Chose **`Optional[float]`**, matching the repo's own established, universal convention for monetary fields (verified: every `_amount`/`_fee` response field across quotes.py, payins/quotes.py, payins.py, transfers.py, payouts.py is `float`; none use `int` or `str` for money). No competing convention exists to override this.

Also added `billing_fee_amount: NotRequired[Optional[float]]` to `GetPayinTrackResponse` and `CreateEvmPayinResponse`. **Correction to my own prior work**: these map to the same wire schemas as `Payin` (`PayinOut`/`CreatePayinOut` respectively, both of which have this field), but did not model it at all before this PR -- not "modeled with the wrong type," simply absent. The `.api-sync/unmodeled.json` entry I wrote in #58 for `CreatePayinOut.billing_fee_amount` incorrectly asserted "Payin/GetPayinTrackResponse do model it"; only `Payin` did. Fixed now, correctly typed from the start, on all three.

### 3. `BankAccountType`: `Literal["checking", "savings"]` -> `Literal["checking", "saving"]`

Contract: `accountType = ['checking', 'saving']` (singular). The API's own payout code branches on the literal string `'saving'`. The plural `"savings"` is a value the API has never accepted -- not an alternate spelling choice, a value that fails.

### 4. `CreateCustodialWalletInput`: add `name: str` (required) and `external_id: NotRequired[Optional[str]]`

`CreateWalletIn.required` on the wire is `['network', 'name']`; `external_id` is present and optional (`["string","null"]`). Before this PR, `CreateCustodialWalletInput` modeled only `customer_id` and `network` -- every custodial wallet creation through this SDK was rejected by the API for a missing required field. `name` is a bare required key here (not `NotRequired`) because the API genuinely requires it; unlike a normal "new optional field on an already-published TypedDict" case, there is no previously-working caller to protect, since every prior call was already failing server-side. node/go/swift already send `name`; python and php did not.

No method code change was needed: `create()` already forwards every non-`customer_id` key verbatim (`payload = {k: v for k, v in data.items() if k != "customer_id"}`), so `name`/`external_id` now flow through automatically once the type carries them -- proven by the updated `mock_request.assert_called_once_with(...)` body assertions in `test_custodial_wallets.py`.

## unmodeled.json cleanup

Removed the four now-fixed entries (stale records misdirect the next reader):
- `{"kind": "enum", "enum": "BankAccountType", "missing_values": ["saving"]}`
- `{"kind": "property", "schema": "CreateWalletIn", "field": "name"}`
- `{"kind": "property", "schema": "CreateWalletIn", "field": "external_id"}`
- `{"kind": "property", "schema": "CreatePayinOut", "field": "billing_fee_amount"}`

`KycStatus`'s divergence (2 of 8 members modeled) is untouched -- separate, still undecided, not part of this PR.

142 -> **138** entries.

## `--audit-types` delta

```
BEFORE (316 findings):
  PayinOut.billing_fee_amount (Payin in .../payins/payins.py): spec type `number` (expected `float`) but SDK annotation is `str` [annotation: Optional[str]]
  PaginationMetadata.next_page (PaginationMetadata in .../types.py): spec is nullable but SDK annotation `int` has no Optional[...] [annotation: int]
  PaginationMetadata.prev_page (PaginationMetadata in .../types.py): spec is nullable but SDK annotation `int` has no Optional[...] [annotation: int]

AFTER (313 findings):
  (zero matches for billing_fee_amount / next_page / prev_page)
```
Drop of exactly 3 -- exactly the type-mismatch findings this PR fixes. `BankAccountType` and the wallet-create fields are presence/enum-divergence issues tracked in `unmodeled.json`, not `--audit-types` findings (that tool only flags type mismatches on properties the SDK already models); those are the 4 entries removed from `unmodeled.json` above.

`sync.py --check` stays exit 0 (silent) before and after -- these are hand-authored type corrections, not spec-drift the patcher would have applied differently.

## Tests

- New `tests/test_types.py`: explicit TypedDict-annotated literals for all four fixes, so pyright/mypy (both run over `tests/`) enforce the shape at the *assignment*, not just a runtime equality check -- a string `next_page`, a numeric `billing_fee_amount` (plus proof the field is optional on `GetPayinTrackResponse`/`CreateEvmPayinResponse`), `"saving"` as a valid `BankAccountType`, and `name`/`external_id` on `CreateCustodialWalletInput`.
- Updated `test_payouts.py`/`test_payins.py`: pagination fixtures now use string cursors (`"pi_123"`) instead of integers.
- Updated `test_custodial_wallets.py`: both `test_create_custodial_wallet` (async + sync) now pass `name` and assert it's in the actual POST body sent; new `test_create_custodial_wallet_with_external_id` proves `external_id` flows through when supplied.

## Proof

```
$ uv sync --group dev --group test
Resolved 28 packages ... Checked 27 packages

$ uv run ruff format --check .
72 files already formatted

$ uv run ruff check .
All checks passed!

$ uv run pyright
0 errors, 0 warnings, 0 informations

$ uv run mypy .
Success: no issues found in 69 source files

$ uv run pytest --tb=short -q
...
215 passed in 1.00s

$ python3 .api-sync/check_contract.py
Checked 1347 declared TypedDict fields across 175 classes against 527 known wire keys.
Direction B (fields) -- warning only: 232 spec property name(s) are not declared by any SDK TypedDict.
Direction A and B: PASSED.

$ python3 .api-sync/sync.py --validate-map
Map validity: OK

$ python3 .api-sync/sync.py --check
(silent, exit 0)
```

**Determinism** (two independent copies of this branch, `sync.py --apply --spec .api-sync/spec-snapshot.json` re-run in each -- unaffected by these hand-authored fixes, confirming the patcher itself is untouched and still behaves correctly):
```
No changes.
No changes.
$ diff -rq /tmp/fix-det-a /tmp/fix-det-b
(no output -- byte-identical)
```

## Version bump

Title uses `feat:` to produce a **minor** bump (these change public TypedDict/Literal shapes, not just internal behavior). Not `fix:` (patch) because the task explicitly calls for minor given the type-surface change, and not `feat!:`/breaking (these correct wrong types to match an unchanged wire contract; nothing that previously worked correctly stops working).

Per the working rules: fresh clone, branch off current `main` (post #58/#59/#60/#61/#62), not merged, opening for review and stopping here.

https://claude.ai/code/session_01F1stiNzuNtJXoXtiW9ZCbs
