### PR TITLE
fix(upload): add required type and optional metadata to analyze input

### DIFF
--- a/src/blindpay/resources/upload/upload.py
+++ b/src/blindpay/resources/upload/upload.py
@@ -1,9 +1,36 @@
-from typing_extensions import Literal, TypedDict
+from typing import Optional
+
+from typing_extensions import Literal, NotRequired, TypedDict
 
 from ..._internal.api_client import InternalApiClient, InternalApiClientSync
 from ...types import ApprovalRate, BlindpayApiResponse
 
 UploadBucket = Literal["avatar", "onboarding", "limit_increase"]
+
+UploadAnalyzeDocumentType = Literal[
+    "proof_of_address",
+    "identity_document",
+    "incorporation_document",
+    "proof_of_ownership",
+    "source_of_funds",
+    "selfie",
+    "bank_statement",
+    "tax_return",
+    "proof_of_income",
+    "financial_statement",
+    "invoice",
+    "transaction_document",
+    "passport",
+    "pay_stub",
+    "employment_letter",
+    "investment",
+    "crypto_exchange",
+    "blockchain_wallet",
+    "contract",
+    "accounts_receivable",
+    "merchant_processor",
+    "shareholder_loan",
+]
 
 
 class UploadInput(TypedDict):
@@ -17,6 +44,8 @@ class UploadResponse(TypedDict):
 
 class UploadAnalyzeInput(TypedDict):
     file: str
+    type: UploadAnalyzeDocumentType
+    metadata: NotRequired[Optional[str]]
 
 
 class UploadAnalyzeOutput(TypedDict):

--- a/tests/resources/test_upload.py
+++ b/tests/resources/test_upload.py
@@ -23,6 +23,25 @@ class TestUpload:
             assert response["data"] == mocked_data
             mock_request.assert_called_once_with("POST", "/upload", {"bucket": "avatar", "file": "base64data"})
 
+    @pytest.mark.asyncio
+    async def test_analyze(self):
+        mocked_data = {"approval_rate": "high", "description": "Looks valid"}
+
+        with patch.object(self.blindpay._api, "_request") as mock_request:
+            mock_request.return_value = {"data": mocked_data, "error": None}
+
+            response = await self.blindpay.upload.analyze(
+                {"file": "base64data", "type": "proof_of_address", "metadata": '{"full_name":"Jane Doe"}'}
+            )
+
+            assert response["error"] is None
+            assert response["data"] == mocked_data
+            mock_request.assert_called_once_with(
+                "POST",
+                "/upload/analyze",
+                {"file": "base64data", "type": "proof_of_address", "metadata": '{"full_name":"Jane Doe"}'},
+            )
+
 
 class TestUploadSync:
     @pytest.fixture(autouse=True)
@@ -40,3 +59,21 @@ class TestUploadSync:
             assert response["error"] is None
             assert response["data"] == mocked_data
             mock_request.assert_called_once_with("POST", "/upload", {"bucket": "avatar", "file": "base64data"})
+
+    def test_analyze(self):
+        mocked_data = {"approval_rate": "high", "description": "Looks valid"}
+
+        with patch.object(self.blindpay._api, "_request") as mock_request:
+            mock_request.return_value = {"data": mocked_data, "error": None}
+
+            response = self.blindpay.upload.analyze(
+                {"file": "base64data", "type": "proof_of_address", "metadata": '{"full_name":"Jane Doe"}'}
+            )
+
+            assert response["error"] is None
+            assert response["data"] == mocked_data
+            mock_request.assert_called_once_with(
+                "POST",
+                "/upload/analyze",
+                {"file": "base64data", "type": "proof_of_address", "metadata": '{"full_name":"Jane Doe"}'},
+            )


### PR DESCRIPTION
## Summary
- `UploadAnalyzeInput` only declared `file`. The API's `POST /v1/upload/analyze` requires `type` (document kind enum) and accepts optional `metadata`. As typed, `analyze()` could never build a valid request.
- Added `UploadAnalyzeDocumentType` Literal covering the spec's 21 enum values, made `type` required, and `metadata` optional (`NotRequired[Optional[str]]`).

## Test plan
- [x] Added async/sync unit tests exercising `analyze()` with `type` and `metadata`
- [x] `pytest`, `pyright`, `mypy`, `ruff` all pass
- [x] `.api-sync/sync.py --check` and `.api-sync/check_contract.py` pass unchanged (this schema is a recorded exclusion in spec-map.json, unaffected by this fix)

Claude-Session: https://claude.ai/code/session_01F1stiNzuNtJXoXtiW9ZCbs